### PR TITLE
Embed `sinon-ie.js` into this module in order to wrap with a hacky IE version check

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,13 +1,18 @@
 var path = require('path');
 
 var createPattern = function(file) {
-  return {pattern: file, included: true, served: true, watched: false};
+  return {
+    pattern: file,
+    included: true,
+    served: true,
+    watched: false
+  };
 };
 
 var initSinon = function(files) {
-  var sinonPath = path.dirname(require.resolve('sinon')) + '/../pkg';
-  files.unshift(createPattern('./sinon-ie.js'));
-  files.unshift(createPattern(sinonPath + '/sinon.js'));
+  var sinonPath = path.resolve(path.dirname(require.resolve('sinon')), '..', 'pkg', 'sinon.js');
+  files.unshift(createPattern(path.resolve(__dirname, 'sinon-ie.js')));
+  files.unshift(createPattern(sinonPath));
 };
 
 initSinon.$inject = ['config.files'];

--- a/index.js
+++ b/index.js
@@ -1,17 +1,17 @@
 var path = require('path');
 
 var createPattern = function(file) {
-    return {pattern: file, included: true, served: true, watched: false};
+  return {pattern: file, included: true, served: true, watched: false};
 };
 
 var initSinon = function(files) {
-    var sinonPath = path.dirname(require.resolve('sinon')) + '/../pkg';
-    files.unshift(createPattern(sinonPath + '/sinon-ie.js'));
-    files.unshift(createPattern(sinonPath + '/sinon.js'));
+  var sinonPath = path.dirname(require.resolve('sinon')) + '/../pkg';
+  files.unshift(createPattern('./sinon-ie.js'));
+  files.unshift(createPattern(sinonPath + '/sinon.js'));
 };
 
 initSinon.$inject = ['config.files'];
 
 module.exports = {
-    'framework:sinon': ['factory', initSinon]
+  'framework:sinon': ['factory', initSinon]
 };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "sinon",
         "mock"
     ],
-    "version": "1.0.2",
+    "version": "2.0.0-rc1",
     "main": "./index.js",
     "author": {
         "name": "Levi Buzolic",
@@ -38,7 +38,5 @@
     },
     "engines": {
         "node": ">= 0.10.0"
-    },
-    "_id": "karma-sinon-ie@1.0.2",
-    "_from": "karma-sinon-ie@*"
+    }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "sinon",
         "mock"
     ],
-    "version": "2.0.0-rc1",
+    "version": "2.0.0-rc2",
     "main": "./index.js",
     "author": {
         "name": "Levi Buzolic",

--- a/sinon-ie.js
+++ b/sinon-ie.js
@@ -1,0 +1,68 @@
+/**
+ * Sinon.JS 1.17.2, 2015/10/21
+ *
+ * @author Christian Johansen (christian@cjohansen.no)
+ * @author Contributors: https://github.com/cjohansen/Sinon.JS/blob/master/AUTHORS
+ *
+ * (The BSD License)
+ *
+ * Copyright (c) 2010-2014, Christian Johansen, christian@cjohansen.no
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without modification,
+ * are permitted provided that the following conditions are met:
+ *
+ *   * Redistributions of source code must retain the above copyright notice,
+ *     this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above copyright notice,
+ *     this list of conditions and the following disclaimer in the documentation
+ *     and/or other materials provided with the distribution.
+ *   * Neither the name of Christian Johansen nor the names of his contributors
+ *     may be used to endorse or promote products derived from this software
+ *     without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+ * THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+var __SINON_MSIE_VERSION = null;
+(function(){
+  if (navigator && navigator.userAgent) {
+    var match = navigator.userAgent.match(/MSIE (\d+\.\d+)/);
+    if (match && match.length == 2) {
+      __SINON_MSIE_VERSION = parseFloat(match[1]);
+    }
+  }
+})();
+
+if (typeof window !== "undefined" && __SINON_MSIE_VERSION < 11) {
+  function setTimeout() {}
+  function clearTimeout() {}
+  function setImmediate() {}
+  function clearImmediate() {}
+  function setInterval() {}
+  function clearInterval() {}
+  function Date() {}
+  function XMLHttpRequest() {}
+  function XDomainRequest() {}
+
+  // Reassign the original functions. Now their writable attribute
+  // should be true. Hackish, I know, but it works.
+  setTimeout = sinon.timers.setTimeout;
+  clearTimeout = sinon.timers.clearTimeout;
+  setImmediate = sinon.timers.setImmediate;
+  clearImmediate = sinon.timers.clearImmediate;
+  setInterval = sinon.timers.setInterval;
+  clearInterval = sinon.timers.clearInterval;
+  Date = sinon.timers.Date;
+  XMLHttpRequest = sinon.xhr.XMLHttpRequest || undefined;
+  XDomainRequest = sinon.xdr.XDomainRequest || undefined;
+}


### PR DESCRIPTION
Related to and fixes sinonjs/sinon#848

In order to get Sinon IE on IE11 and Edge working properly I needed to wrap a IE version check around the `sinon-ie.js` file, but because the logic to include `sinon-ie.js` is executed in node with karma and not in the browser at runtime I needed to modify the `sinon-ie.js` file. So, to do this, I've pulled `sinon-ie.js` into this package and wrapped it up in a pretty hacky version check.

In my limited testing it looks like this should "just work" with all versions of IE now (and hopefully into the future).
